### PR TITLE
Enforces limits on inputs

### DIFF
--- a/frontend/src/common/suggestitheader/suggestitheader.js
+++ b/frontend/src/common/suggestitheader/suggestitheader.js
@@ -91,7 +91,10 @@ class SuggestITHeaderView extends Component {
                                                             )
                                                                 this.login();
                                                         }}
-                                                        //Why not using DigitTextField, 1. No onKeyPress event, 2. No autofocus
+                                                        inputProps={{
+                                                            maxlength: 50
+                                                        }}
+                                                        //Why not using DigitTextField, 1. No onKeyPress event, 2. No autofocus, 3. No inputProps
                                                     />
                                                 ),
                                                 renderButtons: (

--- a/frontend/src/use-cases/home/Prompt/Prompt.js
+++ b/frontend/src/use-cases/home/Prompt/Prompt.js
@@ -1,12 +1,11 @@
 import React, { useState } from "react";
 import {
-    DigitTextField,
-    DigitTextArea,
     DigitButton,
     DigitSwitch,
     DigitText,
     DigitToastActions,
 } from "@cthit/react-digit-components";
+import TextField from "@material-ui/core/TextField";
 import {
     addSuggestion,
     updateSuggestions,
@@ -45,29 +44,39 @@ const PromptView = ({ toastOpen }) => {
         <div className="prompt">
             <div className="innerPrompt">
                 <DigitText.Heading6 text="New Suggestion" />
-                <DigitTextField
+                <TextField
                     error={errors.title_error}
-                    errorMessage={title_error_message}
+                    helperText={errors.title_error && title_error_message}
                     onChange={e => setTitle(e.target.value)}
                     value={title}
-                    upperLabel="Title"
+                    label="Title"
+                    inputProps={{
+                        maxlength: 50
+                    }}
                 />
                 <br />
                 {/*Change this tag to DigitTextArea when the*/}
-                <DigitTextArea
-                    error={errors.description_error}
-                    errorMessage={description_error_message}
-                    onChange={e => setText(e.target.value)}
-                    value={text}
-                    upperLabel="Suggestion"
+                <TextField
+                    multiline
                     rows={5}
                     rowsMax={10}
+                    error={errors.description_error}
+                    helperText={errors.description_error && description_error_message}
+                    onChange={e => setText(e.target.value)}
+                    value={text}
+                    label="Suggestion"
+                    inputProps={{
+                        maxlength: 500
+                    }}
                 />
-                <DigitTextField
+                <TextField
                     onChange={e => setAuthor(e.target.value)}
                     value={author}
+                    label="CID"
                     disabled={anonymous_author}
-                    upperLabel="CID"
+                    inputProps={{
+                        maxlength: 50
+                    }}
                 />
                 <DigitSwitch
                     value={anonymous_author}


### PR DESCRIPTION
Addresses #8. Using MUI `TextField` instead of `DigitTextField` and `DigitTextArea` because we need access to `intputProps` to set the maxlength.